### PR TITLE
Issues #9449, #8104: Prevent blocker stealing tab handling of the curent focus root

### DIFF
--- a/framework/source/class/qx/ui/core/Blocker.js
+++ b/framework/source/class/qx/ui/core/Blocker.js
@@ -115,6 +115,14 @@ qx.Class.define("qx.ui.core.Blocker",
      * events, this is useful to block keyboard input on other widgets.
      * Take care that only one blocker instance will be kept active, otherwise your
      * browser will freeze.
+     * 
+     * Setting this property to true is ignored, if the blocker is attached to a
+     * widget with a focus handler, as this would mean that the focus handler
+     * tries to activate the widget behind the blocker.
+     * 
+     * fixes:
+     *     https://github.com/qooxdoo/qooxdoo/issues/9449
+     *     https://github.com/qooxdoo/qooxdoo/issues/8104
      */
     keepBlockerActive :
     {
@@ -485,7 +493,20 @@ qx.Class.define("qx.ui.core.Blocker",
      * Sets the blocker element to active.
      */
     __activateBlockerElement : function() {
-      if (this.getKeepBlockerActive()) {
+      if (this.getKeepBlockerActive() && 
+          // 
+          // If this._widget is attached to the focus handler as a focus root,
+          // activating the blocker after this widget was deactivated,
+          // leads to the focus handler re-activate the widget behind
+          // the blocker, loosing tab handling for this._widget which is
+          // visually in front. Hence we prevent activating the 
+          // blocker in this situation.
+          //
+          // fixes:
+          //  https://github.com/qooxdoo/qooxdoo/issues/9449
+          //  https://github.com/qooxdoo/qooxdoo/issues/8104
+          //
+          !qx.ui.core.FocusHandler.getInstance().isFocusRoot(this._widget)) {
         this.getBlockerElement().activate();
       }
     }


### PR DESCRIPTION
If the widget attached to the blocker is also attached to the `qx.ui.core.FocusHandler` as a focus root, activating the blocker after this widget was activated, leads to the focus handler re-activate the widget behind the blocker, loosing tab handling for widget which is visually in front. Hence we prevent activating the blocker in this situation.

Fixes #9449, #8104